### PR TITLE
updated the curl command to force tls '-1'

### DIFF
--- a/installer.sh
+++ b/installer.sh
@@ -245,7 +245,7 @@ chmod -R 600 /var/log/userify-shim.log
 
 # kick off shim.py
 [ -z "$PYTHON" ] && PYTHON="$(which python)"
-curl -f${SELFSIGNED}Ss https://$static_host/shim.py | $PYTHON -u >>/var/log/userify-shim.log 2>&1
+curl -1 -f${SELFSIGNED}Ss https://$static_host/shim.py | $PYTHON -u >>/var/log/userify-shim.log 2>&1
 
 if [ $? != 0 ]; then
     # extra backoff in event of failure,

--- a/shim.py
+++ b/shim.py
@@ -77,7 +77,7 @@ chmod -R 600 /var/log/userify-shim.log
 
 # kick off shim.py
 [ -z "$PYTHON" ] && PYTHON="$(which python)"
-curl -f${SELFSIGNED}Ss https://$static_host/shim.py | $PYTHON -u >>/var/log/userify-shim.log 2>&1
+curl -1 -f${SELFSIGNED}Ss https://$static_host/shim.py | $PYTHON -u >>/var/log/userify-shim.log 2>&1
 
 if [ $? != 0 ]; then
     # extra backoff in event of failure,


### PR DESCRIPTION
 curl -1 -f${SELFSIGNED}Ss https://$static_host/shim.py | $PYTHON -u >>/var/log/userify-shim.log 2>&1

This is to resovle issue with SSL error
Linked to the following security notices
https://rhn.redhat.com/errata/RHSA-2016-0591.html
http://lwn.net/Articles/682553/

 Changes to be committed:
	modified:   installer.sh
	modified:   shim.py

https://github.com/userify/shim/issues/25